### PR TITLE
changed layout to use commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 venv/
+project/
+ite-4-demo-test-repo/


### PR DESCRIPTION
Added the usage of commits in the layout using a simple git resolver. Waiting for PR to merge in @SolidifiedRay's `ITE-4-monkey-patch` to update branch so it contains the resolver and minor changes to runlib.